### PR TITLE
Add start/stop cmdargs and change cmd parsing to use getopt_long()

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@ There are a few options that you can see with `./robsize --help`:
 ```
 Usage: robsize [TEST_ID] [OPTIONS]
 
-	--csv      	Output in csv format suitable for plotting
-	--slow     	Run more iterations making the test slower but potentiallly more accurate
-	--fast     	Run fewer iterations making the test faster but potentiallly less accurate
-	--superfast	Run at ludicrous speed which is even less accurate than --fast
-	--write-asm	Print the raw generated instructions to a file and quit
-	--list     	List the available tests and their IDs
+	--csv      	  Output in csv format suitable for plotting
+	--slow     	  Run more iterations making the test slower but potentiallly more accurate
+	--fast     	  Run fewer iterations making the test faster but potentiallly less accurate
+	--superfast	  Run at ludicrous speed which is even less accurate than --fast
+	--write-asm	  Print the raw generated instructions to a file and quit
+	--list     	  List the available tests and their IDs
+	--start=START Use START to specify the initial value of filler instruction count (Default = 16)
+	--stop=STOP   Use STOP to specify the maximum value of filler instruction count (Default = 256)
 ```
 
 ## Interesting Tests

--- a/robsize.cc
+++ b/robsize.cc
@@ -491,9 +491,9 @@ int main(int argc, const char *argv[])
 
     // use 100 if we are printing the buffer because some things don't show up
     // until more instructions are used
-    int start = getenv_int("START", print_ibuf ? 33 : 16);
-    int stop  = getenv_int("STOP", 250);
-    for (int icount = start; icount < stop; icount += 1)
+    int start_icount = getenv_int("START", print_ibuf ? 33 : 16);
+    int stop_icount  = getenv_int("STOP", 250);
+    for (int icount = start_icount; icount < stop_icount; icount += 1)
     {
         make_routine(ibuf, dbuf, dbuf+((8388608+4096)/sizeof(void*)), icount, instr_type);
         routine();

--- a/robsize.cc
+++ b/robsize.cc
@@ -402,14 +402,14 @@ static int instr_type = 4;	// Default to two-byte nop
 
 void print_usage() {
     fprintf(stderr, "Usage: robsize [TEST_ID] [OPTIONS]\n\n"
-    "\t--csv      \tOutput in csv format suitable for plotting\n"
-    "\t--slow     \tRun more iterations making the test slower but potentiallly more accurate\n"
-    "\t--fast     \tRun fewer iterations making the test faster but potentiallly less accurate\n"
-    "\t--superfast\tRun at ludicrous speed which is even less accurate than --fast\n"
-    "\t--write-asm\tPrint the raw generated instructions to a file and quit\n"
-    "\t--list     \tList the available tests and their IDs\n"
-    "\t--start    \t(int) Value to start filler instruction count at.\n"
-    "\t--stop     \t(int) Value to stop filler instruction count at.\n"
+    "\t--csv        \tOutput in csv format suitable for plotting\n"
+    "\t--slow       \tRun more iterations making the test slower but potentiallly more accurate\n"
+    "\t--fast       \tRun fewer iterations making the test faster but potentiallly less accurate\n"
+    "\t--superfast  \tRun at ludicrous speed which is even less accurate than --fast\n"
+    "\t--write-asm  \tPrint the raw generated instructions to a file and quit\n"
+    "\t--list       \tList the available tests and their IDs\n"
+    "\t--start=START\tUse START to specify the initial value of filler instruction count (Default = 16)\n"
+    "\t--stop=STOP  \tUse STOP to specify the maximum value of filler instruction count (Default = 256)\n"
     );
 }
 

--- a/robsize.cc
+++ b/robsize.cc
@@ -424,7 +424,7 @@ void print_tests() {
 /* Command line options for getopt_long() */
 static struct option long_options[] = {
     {"help",       no_argument, NULL, 'h'},
-    {"list",       no_argument, NULL, 'h'},
+    {"list",       no_argument, NULL, 'l'},
     {"csv",        no_argument, NULL, 'c'},
     {"write-asm",  no_argument, NULL, 'w'},
     {"slow",       no_argument, NULL, 's'},
@@ -442,6 +442,10 @@ void handle_args(int argc, char *argv[]) {
         switch (optval) {
             case 'h': /* help */
                 print_usage();
+                exit(EXIT_SUCCESS);
+                break;
+            case 'l': /* list */
+                print_tests();
                 exit(EXIT_SUCCESS);
                 break;
             case 'c': /* csv */

--- a/robsize.cc
+++ b/robsize.cc
@@ -27,6 +27,8 @@ static int its = 8192;
 static const int unroll = 17;
 static bool print_ibuf;
 static bool plot_mode; // make csv output, extraneous output to stdout
+static int start_icount = 16;
+static int stop_icount = 256;
 
 enum FLAGS {
     // doesn't need compensation for the load op, i.e., it uses different
@@ -406,6 +408,8 @@ void print_usage() {
     "\t--superfast\tRun at ludicrous speed which is even less accurate than --fast\n"
     "\t--write-asm\tPrint the raw generated instructions to a file and quit\n"
     "\t--list     \tList the available tests and their IDs\n"
+    "\t--start    \t(int) Value to start filler instruction count at.\n"
+    "\t--stop     \t(int) Value to stop filler instruction count at.\n"
     );
 }
 
@@ -426,6 +430,8 @@ static struct option long_options[] = {
     {"slow",       no_argument, NULL, 's'},
     {"fast",       no_argument, NULL, 'f'},
     {"superfast",  no_argument, NULL, 'g'},
+    {"start", required_argument, NULL, 'i'},
+    {"stop",  required_argument, NULL, 'j'},
     {0, 0, 0, 0}
 };
 
@@ -455,6 +461,20 @@ void handle_args(int argc, char *argv[]) {
                 its >>= 4;
                 outer_its >>= 3;
                 break;
+            case 'i': /* start */
+                if (sscanf(optarg, "%d", &start_icount) <= 0) {
+                    fprintf(stderr, "Unrecognized value for --start: %s\n",  optarg);
+                    print_usage();
+                    exit(EXIT_FAILURE);
+                }
+                break;
+            case 'j': /* stop */
+                if (sscanf(optarg, "%d", &stop_icount) <= 0) {
+                    fprintf(stderr, "Unrecognized value for --stop: %s\n",  optarg);
+                    print_usage();
+                    exit(EXIT_FAILURE);
+                }
+                break;
             default:
                 print_usage();
                 exit(EXIT_FAILURE);
@@ -475,11 +495,6 @@ void handle_args(int argc, char *argv[]) {
         print_usage();
         exit(EXIT_FAILURE);
     }
-}
-
-int getenv_int(const char *var, int def) {
-    const char *val = getenv(var);
-    return val ? atoi(val) : def;
 }
 
 int main(int argc, char *argv[])
@@ -510,8 +525,6 @@ int main(int argc, char *argv[])
 
     // use 100 if we are printing the buffer because some things don't show up
     // until more instructions are used
-    int start_icount = getenv_int("START", print_ibuf ? 33 : 16);
-    int stop_icount  = getenv_int("STOP", 250);
     for (int icount = start_icount; icount < stop_icount; icount += 1)
     {
         make_routine(ibuf, dbuf, dbuf+((8388608+4096)/sizeof(void*)), icount, instr_type);


### PR DESCRIPTION
Minor changes:
- sort include headers alphabetically
- remove support for setting start/stop counts using environment vars
- fix aliasing variable name start/stop